### PR TITLE
1단계 - 문자열 덧셈 계산기

### DIFF
--- a/src/main/java/calculator/AbstractCalculateStrategy.java
+++ b/src/main/java/calculator/AbstractCalculateStrategy.java
@@ -1,0 +1,21 @@
+package calculator;
+
+import java.util.Arrays;
+
+public abstract class AbstractCalculateStrategy implements CalculateStrategy {
+
+    protected int parseNonNegativeNumber(final String value) {
+        final int number = Integer.parseInt(value);
+        if (number < 0) {
+            throw new IllegalArgumentException("문자열 계산기는 음수를 지원하지 않습니다.");
+        }
+        return number;
+    }
+
+    protected int calculateWithDelimiter(final String text, final String delimiter) {
+        return Arrays.stream(text.split(delimiter))
+                .mapToInt(this::parseNonNegativeNumber)
+                .sum();
+    }
+
+}

--- a/src/main/java/calculator/CalculateStrategy.java
+++ b/src/main/java/calculator/CalculateStrategy.java
@@ -1,0 +1,8 @@
+package calculator;
+
+public interface CalculateStrategy {
+
+    boolean isTarget(String text);
+    int calculate(String text);
+
+}

--- a/src/main/java/calculator/CalculateStrategyManager.java
+++ b/src/main/java/calculator/CalculateStrategyManager.java
@@ -1,0 +1,25 @@
+package calculator;
+
+import java.util.List;
+
+public class CalculateStrategyManager {
+
+    private final List<CalculateStrategy> calculateStrategies;
+
+    public CalculateStrategyManager() {
+        this.calculateStrategies = List.of(
+                new NullOrEmptyCalculateStrategy(),
+                new NumberPatternCalculateStrategy(),
+                new SeparatorCalculateStrategy(),
+                new CustomSeparatorCalculateStrategy()
+        );
+    }
+
+    public CalculateStrategy findStrategy(final String text) {
+        return calculateStrategies.stream()
+                .filter(strategy -> strategy.isTarget(text))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 형식입니다."));
+    }
+    
+}

--- a/src/main/java/calculator/CalculateStrategyManager.java
+++ b/src/main/java/calculator/CalculateStrategyManager.java
@@ -4,18 +4,14 @@ import java.util.List;
 
 public class CalculateStrategyManager {
 
-    private final List<CalculateStrategy> calculateStrategies;
+    private static final List<CalculateStrategy> calculateStrategies = List.of(
+            new NullOrEmptyCalculateStrategy(),
+            new NumberPatternCalculateStrategy(),
+            new SeparatorCalculateStrategy(),
+            new CustomSeparatorCalculateStrategy()
+    );
 
-    public CalculateStrategyManager() {
-        this.calculateStrategies = List.of(
-                new NullOrEmptyCalculateStrategy(),
-                new NumberPatternCalculateStrategy(),
-                new SeparatorCalculateStrategy(),
-                new CustomSeparatorCalculateStrategy()
-        );
-    }
-
-    public CalculateStrategy findStrategy(final String text) {
+    public static CalculateStrategy findStrategy(final String text) {
         return calculateStrategies.stream()
                 .filter(strategy -> strategy.isTarget(text))
                 .findFirst()

--- a/src/main/java/calculator/CustomSeparatorCalculateStrategy.java
+++ b/src/main/java/calculator/CustomSeparatorCalculateStrategy.java
@@ -22,7 +22,9 @@ public class CustomSeparatorCalculateStrategy extends AbstractCalculateStrategy 
 
     private Matcher getMatcher(final String text) {
         Matcher matcher = CUSTOM_SEPARATOR_PATTERN.matcher(text);
-        matcher.find();
+        if (!matcher.find()) {
+            throw new IllegalArgumentException("커스텀 구분자 패턴에 일치하지 않습니다.");
+        }
         return matcher;
     }
 

--- a/src/main/java/calculator/CustomSeparatorCalculateStrategy.java
+++ b/src/main/java/calculator/CustomSeparatorCalculateStrategy.java
@@ -1,0 +1,30 @@
+package calculator;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CustomSeparatorCalculateStrategy extends AbstractCalculateStrategy {
+
+    private static final Pattern CUSTOM_SEPARATOR_PATTERN = Pattern.compile("//(.)\n(.*)");
+    private static final int CUSTOM_DELIMITER = 1;
+    private static final int TARGET_TEXT = 2;
+
+    @Override
+    public boolean isTarget(final String text) {
+        return CUSTOM_SEPARATOR_PATTERN.matcher(text).find();
+    }
+
+    @Override
+    public int calculate(final String text) {
+        Matcher matcher = getMatcher(text);
+        return calculateWithDelimiter(matcher.group(TARGET_TEXT), matcher.group(CUSTOM_DELIMITER));
+    }
+
+    private Matcher getMatcher(final String text) {
+        Matcher matcher = CUSTOM_SEPARATOR_PATTERN.matcher(text);
+        matcher.find();
+        return matcher;
+    }
+
+}
+

--- a/src/main/java/calculator/NullOrEmptyCalculateStrategy.java
+++ b/src/main/java/calculator/NullOrEmptyCalculateStrategy.java
@@ -1,6 +1,6 @@
 package calculator;
 
-public class NullOrEmptyCalculateStrategy extends AbstractCalculateStrategy {
+public class NullOrEmptyCalculateStrategy implements CalculateStrategy {
 
     private static final int NULL_OR_EMPTY_RETURN_VALUE = 0;
 

--- a/src/main/java/calculator/NullOrEmptyCalculateStrategy.java
+++ b/src/main/java/calculator/NullOrEmptyCalculateStrategy.java
@@ -1,0 +1,17 @@
+package calculator;
+
+public class NullOrEmptyCalculateStrategy extends AbstractCalculateStrategy {
+
+    private static final int NULL_OR_EMPTY_RETURN_VALUE = 0;
+
+    @Override
+    public boolean isTarget(final String text) {
+        return (text == null) || (text.isBlank());
+    }
+
+    @Override
+    public int calculate(final String text) {
+        return NULL_OR_EMPTY_RETURN_VALUE;
+    }
+
+}

--- a/src/main/java/calculator/NumberPatternCalculateStrategy.java
+++ b/src/main/java/calculator/NumberPatternCalculateStrategy.java
@@ -1,0 +1,17 @@
+package calculator;
+
+public class NumberPatternCalculateStrategy extends AbstractCalculateStrategy {
+
+    private static final String NUMBER_PATTERN = "-?\\d+(\\.\\d+)?";
+
+    @Override
+    public boolean isTarget(final String text) {
+        return text.matches(NUMBER_PATTERN);
+    }
+
+    @Override
+    public int calculate(final String text) {
+        return parseNonNegativeNumber(text);
+    }
+
+}

--- a/src/main/java/calculator/SeparatorCalculateStrategy.java
+++ b/src/main/java/calculator/SeparatorCalculateStrategy.java
@@ -1,0 +1,21 @@
+package calculator;
+
+import java.util.regex.Pattern;
+
+public class SeparatorCalculateStrategy extends AbstractCalculateStrategy {
+
+    private static final String SEPARATOR = "[,:]";
+    private static final Pattern COMPILED_SEPARATOR_PATTERN = Pattern.compile("[,:]");
+
+    @Override
+    public boolean isTarget(final String text) {
+        return COMPILED_SEPARATOR_PATTERN.matcher(text).find();
+    }
+
+    @Override
+    public int calculate(final String text) {
+        return calculateWithDelimiter(text, SEPARATOR);
+    }
+
+}
+

--- a/src/main/java/calculator/StringCalculator.java
+++ b/src/main/java/calculator/StringCalculator.java
@@ -1,23 +1,16 @@
 package calculator;
 
-import java.util.List;
-
 public class StringCalculator {
 
-    private final List<CalculateStrategy> calculateStrategies = List.of(
-            new NullOrEmptyCalculateStrategy(),
-            new NumberPatternCalculateStrategy(),
-            new SeparatorCalculateStrategy(),
-            new CustomSeparatorCalculateStrategy()
-    );
+    private final CalculateStrategyManager calculateStrategyManager;
+
+    public StringCalculator() {
+        this.calculateStrategyManager = new CalculateStrategyManager();
+    }
 
     public int add(final String text) {
-        return calculateStrategies.stream()
-                .filter(strategy -> strategy.isTarget(text))
-                .findFirst()
-                .map(strategy -> strategy.calculate(text))
-                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 형식입니다."));
+        CalculateStrategy strategy = calculateStrategyManager.findStrategy(text);
+        return strategy.calculate(text);
     }
 
 }
-

--- a/src/main/java/calculator/StringCalculator.java
+++ b/src/main/java/calculator/StringCalculator.java
@@ -16,7 +16,7 @@ public class StringCalculator {
                 .filter(strategy -> strategy.isTarget(text))
                 .findFirst()
                 .map(strategy -> strategy.calculate(text))
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 형식입니다."));
     }
 
 }

--- a/src/main/java/calculator/StringCalculator.java
+++ b/src/main/java/calculator/StringCalculator.java
@@ -2,14 +2,8 @@ package calculator;
 
 public class StringCalculator {
 
-    private final CalculateStrategyManager calculateStrategyManager;
-
-    public StringCalculator() {
-        this.calculateStrategyManager = new CalculateStrategyManager();
-    }
-
     public int add(final String text) {
-        CalculateStrategy strategy = calculateStrategyManager.findStrategy(text);
+        CalculateStrategy strategy = CalculateStrategyManager.findStrategy(text);
         return strategy.calculate(text);
     }
 

--- a/src/main/java/calculator/StringCalculator.java
+++ b/src/main/java/calculator/StringCalculator.java
@@ -1,0 +1,23 @@
+package calculator;
+
+import java.util.List;
+
+public class StringCalculator {
+
+    private final List<CalculateStrategy> calculateStrategies = List.of(
+            new NullOrEmptyCalculateStrategy(),
+            new NumberPatternCalculateStrategy(),
+            new SeparatorCalculateStrategy(),
+            new CustomSeparatorCalculateStrategy()
+    );
+
+    public int add(final String text) {
+        return calculateStrategies.stream()
+                .filter(strategy -> strategy.isTarget(text))
+                .findFirst()
+                .map(strategy -> strategy.calculate(text))
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+}
+

--- a/src/test/java/calculator/StringCalculatorTest.java
+++ b/src/test/java/calculator/StringCalculatorTest.java
@@ -1,0 +1,64 @@
+package calculator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class StringCalculatorTest {
+
+    private StringCalculator calculator;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new StringCalculator();
+    }
+
+    @DisplayName(value = "빈 문자열 또는 null 값을 입력할 경우 0을 반환해야 한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void emptyOrNull(final String text) {
+        assertThat(calculator.add(text)).isZero();
+    }
+
+    @DisplayName(value = "숫자 하나를 문자열로 입력할 경우 해당 숫자를 반환한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"1"})
+    void oneNumber(final String text) {
+        assertThat(calculator.add(text)).isSameAs(Integer.parseInt(text));
+    }
+
+    @DisplayName(value = "숫자 두개를 쉼표(,) 구분자로 입력할 경우 두 숫자의 합을 반환한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"1,2"})
+    void twoNumbers(final String text) {
+        assertThat(calculator.add(text)).isSameAs(3);
+    }
+
+    @DisplayName(value = "구분자를 쉼표(,) 이외에 콜론(:)을 사용할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"1,2:3"})
+    void colons(final String text) {
+        assertThat(calculator.add(text)).isSameAs(6);
+    }
+
+    @DisplayName(value = "//와 \\n 문자 사이에 커스텀 구분자를 지정할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"//;\n1;2;3"})
+    void customDelimiter(final String text) {
+        assertThat(calculator.add(text)).isSameAs(6);
+    }
+
+    @DisplayName(value = "문자열 계산기에 음수를 전달하는 경우 RuntimeException 예외 처리를 한다.")
+    @Test
+    void negative() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> calculator.add("-1"));
+    }
+
+}

--- a/src/test/java/calculator/StringCalculatorTest.java
+++ b/src/test/java/calculator/StringCalculatorTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class StringCalculatorTest {
+class StringCalculatorTest {
 
     private StringCalculator calculator;
 


### PR DESCRIPTION
테스트 조건들을 각각의 전략으로 보고 `SRP, OCP` 에 충실하려고 노력했습니다.
중복로직을 제거하기 위해 처음에는 `default` 메서드로 구현했다가 `interface`가 너무 커지는거 같아 `추상클래스`를 추가했습니다.
결과적으로 아주 간단한 어플리케이션인데 오히려 복잡성만 증가한거 같지만 교육이니 만큼 하고싶은걸 해봤습니다.
리뷰 잘부탁드리겠습니다.

<br>
<br>

## 질문

전략 클래스들을 스프링 빈으로 관리하면 앞으로 전략이 추가되어도 전략클래스만 추가하면 되기때문에 
`StringCalculator` 클래스의 수정이 필요없지만 현재는 새로운 전략이 추가되면 
리스트에 전략클래스를 추가해주던가 클라이언트에서 직접 주입해줘야 하는 방식인데 
이 방법들 말고 좋은 아이디어가 있을까요?

![스크린샷 2023-08-20 오전 12 52 59](https://github.com/next-step/ddd-legacy/assets/58434352/3c6308c1-97a4-4117-a0b4-421247e299a0)

