### PR TITLE
Step3 - 테스트를 통한 코드 보호

### DIFF
--- a/src/main/java/kitchenpos/application/ProductService.java
+++ b/src/main/java/kitchenpos/application/ProductService.java
@@ -1,10 +1,6 @@
 package kitchenpos.application;
 
-import kitchenpos.domain.Menu;
-import kitchenpos.domain.MenuProduct;
-import kitchenpos.domain.MenuRepository;
-import kitchenpos.domain.Product;
-import kitchenpos.domain.ProductRepository;
+import kitchenpos.domain.*;
 import kitchenpos.infra.PurgomalumClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,9 +18,9 @@ public class ProductService {
     private final PurgomalumClient purgomalumClient;
 
     public ProductService(
-        final ProductRepository productRepository,
-        final MenuRepository menuRepository,
-        final PurgomalumClient purgomalumClient
+            final ProductRepository productRepository,
+            final MenuRepository menuRepository,
+            final PurgomalumClient purgomalumClient
     ) {
         this.productRepository = productRepository;
         this.menuRepository = menuRepository;
@@ -55,16 +51,16 @@ public class ProductService {
             throw new IllegalArgumentException();
         }
         final Product product = productRepository.findById(productId)
-            .orElseThrow(NoSuchElementException::new);
+                .orElseThrow(NoSuchElementException::new);
         product.setPrice(price);
         final List<Menu> menus = menuRepository.findAllByProductId(productId);
         for (final Menu menu : menus) {
             BigDecimal sum = BigDecimal.ZERO;
             for (final MenuProduct menuProduct : menu.getMenuProducts()) {
                 sum = sum.add(
-                    menuProduct.getProduct()
-                        .getPrice()
-                        .multiply(BigDecimal.valueOf(menuProduct.getQuantity()))
+                        menuProduct.getProduct()
+                                .getPrice()
+                                .multiply(BigDecimal.valueOf(menuProduct.getQuantity()))
                 );
             }
             if (menu.getPrice().compareTo(sum) > 0) {

--- a/src/main/java/kitchenpos/domain/MenuGroupJpaRepository.java
+++ b/src/main/java/kitchenpos/domain/MenuGroupJpaRepository.java
@@ -1,0 +1,8 @@
+package kitchenpos.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MenuGroupJpaRepository extends MenuGroupRepository, JpaRepository<MenuGroup, UUID> {
+}

--- a/src/main/java/kitchenpos/domain/MenuGroupRepository.java
+++ b/src/main/java/kitchenpos/domain/MenuGroupRepository.java
@@ -1,8 +1,15 @@
 package kitchenpos.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-public interface MenuGroupRepository extends JpaRepository<MenuGroup, UUID> {
+public interface MenuGroupRepository {
+
+    MenuGroup save(MenuGroup menuGroup);
+
+    Optional<MenuGroup> findById(UUID id);
+
+    List<MenuGroup> findAll();
+
 }

--- a/src/main/java/kitchenpos/domain/MenuJpaRepository.java
+++ b/src/main/java/kitchenpos/domain/MenuJpaRepository.java
@@ -1,0 +1,15 @@
+package kitchenpos.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MenuJpaRepository extends MenuRepository, JpaRepository<Menu, UUID> {
+
+    @Query("select m from Menu m join m.menuProducts mp where mp.product.id = :productId")
+    List<Menu> findAllByProductId(@Param("productId") UUID productId);
+
+}

--- a/src/main/java/kitchenpos/domain/MenuRepository.java
+++ b/src/main/java/kitchenpos/domain/MenuRepository.java
@@ -1,15 +1,19 @@
 package kitchenpos.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-public interface MenuRepository extends JpaRepository<Menu, UUID> {
+public interface MenuRepository {
+
+    Menu save(Menu menu);
+
+    Optional<Menu> findById(UUID id);
+
     List<Menu> findAllByIdIn(List<UUID> ids);
 
-    @Query("select m from Menu m join m.menuProducts mp where mp.product.id = :productId")
-    List<Menu> findAllByProductId(@Param("productId") UUID productId);
+    List<Menu> findAllByProductId(UUID productId);
+
+    List<Menu> findAll();
+
 }

--- a/src/main/java/kitchenpos/domain/OrderJpaRepository.java
+++ b/src/main/java/kitchenpos/domain/OrderJpaRepository.java
@@ -1,0 +1,9 @@
+package kitchenpos.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface OrderJpaRepository extends OrderRepository, JpaRepository<Order, UUID> {
+
+}

--- a/src/main/java/kitchenpos/domain/OrderRepository.java
+++ b/src/main/java/kitchenpos/domain/OrderRepository.java
@@ -1,9 +1,17 @@
 package kitchenpos.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-public interface OrderRepository extends JpaRepository<Order, UUID> {
+public interface OrderRepository {
+
+    Order save(Order order);
+
+    Optional<Order> findById(UUID id);
+
+    List<Order> findAll();
+
     boolean existsByOrderTableAndStatusNot(OrderTable orderTable, OrderStatus status);
+
 }

--- a/src/main/java/kitchenpos/domain/OrderTableJpaRepository.java
+++ b/src/main/java/kitchenpos/domain/OrderTableJpaRepository.java
@@ -1,0 +1,6 @@
+package kitchenpos.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderTableJpaRepository extends OrderTableRepository, JpaRepository<OrderTable, Long> {
+}

--- a/src/main/java/kitchenpos/domain/OrderTableRepository.java
+++ b/src/main/java/kitchenpos/domain/OrderTableRepository.java
@@ -1,8 +1,15 @@
 package kitchenpos.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-public interface OrderTableRepository extends JpaRepository<OrderTable, UUID> {
+public interface OrderTableRepository {
+
+    OrderTable save(OrderTable orderTable);
+
+    Optional<OrderTable> findById(UUID id);
+
+    List<OrderTable> findAll();
+
 }

--- a/src/main/java/kitchenpos/domain/ProductJpaRepository.java
+++ b/src/main/java/kitchenpos/domain/ProductJpaRepository.java
@@ -1,0 +1,8 @@
+package kitchenpos.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProductJpaRepository extends ProductRepository, JpaRepository<Product, UUID> {
+}

--- a/src/main/java/kitchenpos/domain/ProductRepository.java
+++ b/src/main/java/kitchenpos/domain/ProductRepository.java
@@ -1,10 +1,15 @@
 package kitchenpos.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-public interface ProductRepository extends JpaRepository<Product, UUID> {
+public interface ProductRepository {
+    Product save(Product product);
+
+    Optional<Product> findById(UUID id);
+
+    List<Product> findAll();
+
     List<Product> findAllByIdIn(List<UUID> ids);
 }

--- a/src/main/java/kitchenpos/infra/DefaultKitchenridersClient.java
+++ b/src/main/java/kitchenpos/infra/DefaultKitchenridersClient.java
@@ -1,0 +1,15 @@
+package kitchenpos.infra;
+
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Component
+public class DefaultKitchenridersClient implements KitchenridersClient {
+
+    @Override
+    public void requestDelivery(final UUID orderId, final BigDecimal amount, final String deliveryAddress) {
+    }
+
+}

--- a/src/main/java/kitchenpos/infra/DefaultPurgomalumClient.java
+++ b/src/main/java/kitchenpos/infra/DefaultPurgomalumClient.java
@@ -1,0 +1,27 @@
+package kitchenpos.infra;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Component
+public class DefaultPurgomalumClient implements PurgomalumClient {
+
+    private final RestTemplate restTemplate;
+
+    public DefaultPurgomalumClient(final RestTemplateBuilder restTemplateBuilder) {
+        this.restTemplate = restTemplateBuilder.build();
+    }
+
+    @Override
+    public boolean containsProfanity(final String text) {
+        final URI url = UriComponentsBuilder.fromUriString("https://www.purgomalum.com/service/containsprofanity")
+                .queryParam("text", text)
+                .build()
+                .toUri();
+        return Boolean.parseBoolean(restTemplate.getForObject(url, String.class));
+    }
+}

--- a/src/main/java/kitchenpos/infra/KitchenridersClient.java
+++ b/src/main/java/kitchenpos/infra/KitchenridersClient.java
@@ -1,12 +1,8 @@
 package kitchenpos.infra;
 
-import org.springframework.stereotype.Component;
-
 import java.math.BigDecimal;
 import java.util.UUID;
 
-@Component
-public class KitchenridersClient {
-    public void requestDelivery(final UUID orderId, final BigDecimal amount, final String deliveryAddress) {
-    }
+public interface KitchenridersClient {
+    void requestDelivery(final UUID orderId, final BigDecimal amount, final String deliveryAddress);
 }

--- a/src/main/java/kitchenpos/infra/PurgomalumClient.java
+++ b/src/main/java/kitchenpos/infra/PurgomalumClient.java
@@ -1,25 +1,7 @@
 package kitchenpos.infra;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
+public interface PurgomalumClient {
 
-import java.net.URI;
+    boolean containsProfanity(final String text);
 
-@Component
-public class PurgomalumClient {
-    private final RestTemplate restTemplate;
-
-    public PurgomalumClient(final RestTemplateBuilder restTemplateBuilder) {
-        this.restTemplate = restTemplateBuilder.build();
-    }
-
-    public boolean containsProfanity(final String text) {
-        final URI url = UriComponentsBuilder.fromUriString("https://www.purgomalum.com/service/containsprofanity")
-            .queryParam("text", text)
-            .build()
-            .toUri();
-        return Boolean.parseBoolean(restTemplate.getForObject(url, String.class));
-    }
 }

--- a/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
@@ -3,27 +3,30 @@ package kitchenpos.application;
 import kitchenpos.domain.MenuGroup;
 import kitchenpos.domain.MenuGroupRepository;
 import kitchenpos.fixture.MenuGroupFixture;
+import kitchenpos.repository.InMemoryMenuGroupRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 
-@SpringBootTest
 class MenuGroupServiceTest {
 
-    @Autowired
     private MenuGroupService menuGroupService;
 
-    @Autowired
     private MenuGroupRepository menuGroupRepository;
+
+    @BeforeEach
+    void setup() {
+        menuGroupRepository = new InMemoryMenuGroupRepository();
+        menuGroupService = new MenuGroupService(menuGroupRepository);
+    }
 
     @Nested
     @DisplayName("메뉴 그룹 생성")
@@ -79,7 +82,7 @@ class MenuGroupServiceTest {
             assertThat(result)
                     .hasSize(2)
                     .extracting(MenuGroup::getId)
-                    .containsExactly(menuGroup1.getId(), menuGroup2.getId());
+                    .containsExactlyInAnyOrder(menuGroup1.getId(), menuGroup2.getId());
         }
     }
 

--- a/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
@@ -33,9 +33,7 @@ class MenuGroupServiceTest {
         @DisplayName("메뉴 그룹 생성 성공")
         void testCreateGroupMenu() {
             // given
-            final String name = "MENU_GROUP_NAME";
-            final MenuGroup request = new MenuGroup();
-            request.setName(name);
+            final MenuGroup request = MenuGroupFixture.createMenuGroup("한마리메뉴");
 
             // when
             final MenuGroup result = menuGroupService.create(request);
@@ -44,7 +42,7 @@ class MenuGroupServiceTest {
             final MenuGroup found = menuGroupRepository.findById(result.getId()).orElse(null);
 
             assertThat(found).isNotNull();
-            assertThat(found.getName()).isEqualTo(name);
+            assertThat(found.getName()).isEqualTo(request.getName());
         }
 
         @ParameterizedTest
@@ -52,8 +50,7 @@ class MenuGroupServiceTest {
         @DisplayName("메뉴 그룹은 이름을 필수로 가진다.")
         void testNullOrEmptyName(final String name) {
             // given
-            final MenuGroup request = new MenuGroup();
-            request.setName(name);
+            final MenuGroup request = MenuGroupFixture.createMenuGroup(name);
 
             // when & then
             assertThatException()
@@ -70,8 +67,8 @@ class MenuGroupServiceTest {
         @DisplayName("등록된 모든 메뉴 그룹을 조회한다.")
         void testFindAllGroupMenu() {
             // given
-            MenuGroup menuGroup1 = MenuGroupFixture.createMenuGroup("MENU_GROUP_NAME_1");
-            MenuGroup menuGroup2 = MenuGroupFixture.createMenuGroup("MENU_GROUP_NAME_2");
+            MenuGroup menuGroup1 = MenuGroupFixture.createMenuGroup("한마리메뉴");
+            MenuGroup menuGroup2 = MenuGroupFixture.createMenuGroup("두마리메뉴");
             menuGroupRepository.save(menuGroup1);
             menuGroupRepository.save(menuGroup2);
 
@@ -81,8 +78,8 @@ class MenuGroupServiceTest {
             // then
             assertThat(result)
                     .hasSize(2)
-                    .extracting(MenuGroup::getName)
-                    .containsExactly("MENU_GROUP_NAME_1", "MENU_GROUP_NAME_2");
+                    .extracting(MenuGroup::getId)
+                    .containsExactly(menuGroup1.getId(), menuGroup2.getId());
         }
     }
 

--- a/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
@@ -1,0 +1,96 @@
+package kitchenpos.application;
+
+import kitchenpos.domain.MenuGroup;
+import kitchenpos.domain.MenuGroupRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+@SpringBootTest
+class MenuGroupServiceTest {
+
+    @Autowired
+    private MenuGroupService menuGroupService;
+
+    @Autowired
+    private MenuGroupRepository menuGroupRepository;
+
+    @Nested
+    @DisplayName("메뉴 그룹 생성")
+    class CreateGroupMenu {
+
+        @Test
+        @DisplayName("메뉴 그룹 생성 성공")
+        void testCreateGroupMenu() {
+            // given
+            final String name = "MENU_GROUP_NAME";
+            final MenuGroup request = new MenuGroup();
+            request.setName(name);
+
+            // when
+            final MenuGroup result = menuGroupService.create(request);
+
+            // then
+            final MenuGroup found = menuGroupRepository.findById(result.getId()).orElse(null);
+
+            assertThat(found).isNotNull();
+            assertThat(found.getName()).isEqualTo(name);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("메뉴 그룹은 이름을 필수로 가진다.")
+        void testNullOrEmptyName(final String name) {
+            // given
+            final MenuGroup request = new MenuGroup();
+            request.setName(name);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> menuGroupService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("그룹 메뉴 조회")
+    class FindGroupMenus {
+
+        @Test
+        @DisplayName("등록된 모든 메뉴 그룹을 조회한다.")
+        void testFindAllGroupMenu() {
+            // given
+            MenuGroup menuGroup1 = createMenuGroup("MENU_GROUP_NAME_1");
+            MenuGroup menuGroup2 = createMenuGroup("MENU_GROUP_NAME_2");
+            menuGroupRepository.save(menuGroup1);
+            menuGroupRepository.save(menuGroup2);
+
+            // when
+            final List<MenuGroup> result = menuGroupService.findAll();
+
+            // then
+            assertThat(result)
+                    .hasSize(2)
+                    .extracting(MenuGroup::getName)
+                    .containsExactly("MENU_GROUP_NAME_1", "MENU_GROUP_NAME_2");
+        }
+    }
+
+    private MenuGroup createMenuGroup(final String name) {
+        final MenuGroup menuGroup = new MenuGroup();
+        menuGroup.setId(UUID.randomUUID());
+        menuGroup.setName(name);
+        return menuGroup;
+    }
+
+}

--- a/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
@@ -2,6 +2,7 @@ package kitchenpos.application;
 
 import kitchenpos.domain.MenuGroup;
 import kitchenpos.domain.MenuGroupRepository;
+import kitchenpos.fixture.MenuGroupFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
@@ -70,8 +70,8 @@ class MenuGroupServiceTest {
         @DisplayName("등록된 모든 메뉴 그룹을 조회한다.")
         void testFindAllGroupMenu() {
             // given
-            MenuGroup menuGroup1 = createMenuGroup("MENU_GROUP_NAME_1");
-            MenuGroup menuGroup2 = createMenuGroup("MENU_GROUP_NAME_2");
+            MenuGroup menuGroup1 = MenuGroupFixture.createMenuGroup("MENU_GROUP_NAME_1");
+            MenuGroup menuGroup2 = MenuGroupFixture.createMenuGroup("MENU_GROUP_NAME_2");
             menuGroupRepository.save(menuGroup1);
             menuGroupRepository.save(menuGroup2);
 
@@ -84,13 +84,6 @@ class MenuGroupServiceTest {
                     .extracting(MenuGroup::getName)
                     .containsExactly("MENU_GROUP_NAME_1", "MENU_GROUP_NAME_2");
         }
-    }
-
-    private MenuGroup createMenuGroup(final String name) {
-        final MenuGroup menuGroup = new MenuGroup();
-        menuGroup.setId(UUID.randomUUID());
-        menuGroup.setName(name);
-        return menuGroup;
     }
 
 }

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -1,11 +1,15 @@
 package kitchenpos.application;
 
 import kitchenpos.domain.*;
+import kitchenpos.fake.FakePurgomalumClient;
 import kitchenpos.fixture.MenuFixture;
 import kitchenpos.fixture.MenuGroupFixture;
 import kitchenpos.fixture.MenuProductFixture;
 import kitchenpos.fixture.ProductFixture;
 import kitchenpos.infra.PurgomalumClient;
+import kitchenpos.repository.InMemoryMenuGroupRepository;
+import kitchenpos.repository.InMemoryMenuRepository;
+import kitchenpos.repository.InMemoryProductRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,9 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -26,26 +27,27 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 
-@SpringBootTest
 class MenuServiceTest {
 
-    @Autowired
     private MenuService menuService;
 
-    @Autowired
     private MenuRepository menuRepository;
 
-    @Autowired
     private ProductRepository productRepository;
 
-    @Autowired
     private MenuGroupRepository menuGroupRepository;
 
-    @MockBean
     private PurgomalumClient purgomalumClient;
+
+    @BeforeEach
+    void setup() {
+        menuRepository = new InMemoryMenuRepository();
+        productRepository = new InMemoryProductRepository();
+        menuGroupRepository = new InMemoryMenuGroupRepository();
+        purgomalumClient = new FakePurgomalumClient();
+        menuService = new MenuService(menuRepository, menuGroupRepository, productRepository, purgomalumClient);
+    }
 
     @Nested
     @DisplayName("메뉴 등록")
@@ -59,7 +61,6 @@ class MenuServiceTest {
             final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
             final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
             final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when
             final Menu result = menuService.create(request);
@@ -83,7 +84,6 @@ class MenuServiceTest {
             final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
             final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
             final Menu request = MenuFixture.createMenu(name, BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when & then
             assertThatException()
@@ -100,7 +100,6 @@ class MenuServiceTest {
             final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
             final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
             final Menu request = MenuFixture.createMenu("후라이드치킨", BigDecimal.valueOf(price), List.of(menuProduct), menuGroup);
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when & then
             assertThatException()
@@ -116,7 +115,6 @@ class MenuServiceTest {
             final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
             final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
             final Menu request = MenuFixture.createMenu("부적절한이름", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(true);
 
             // when & then
             assertThatException()
@@ -132,7 +130,6 @@ class MenuServiceTest {
             final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
             final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
             final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(17_000), List.of(menuProduct), menuGroup);
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when & then
             assertThatException()
@@ -154,8 +151,7 @@ class MenuServiceTest {
             final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
             final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
             final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
-            final Menu menu = menuService.create(request);
+            final Menu menu = menuRepository.save(request);
 
             // when
             final Menu result = menuService.display(menu.getId());
@@ -176,15 +172,13 @@ class MenuServiceTest {
             final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
             final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
             final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
-            final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
-            final Menu menu = menuService.create(request);
-            menu.setPrice(BigDecimal.valueOf(17_000));
+            final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(17_000), List.of(menuProduct), menuGroup);
+            final Menu menu = menuRepository.save(request);
 
             // when & then
             assertThatException()
                     .isThrownBy(() -> menuService.display(menu.getId()))
-                    .isInstanceOf(IllegalArgumentException.class);
+                    .isInstanceOf(IllegalStateException.class);
         }
     }
 
@@ -200,7 +194,6 @@ class MenuServiceTest {
             final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
             final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
             final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
             final Menu menu = menuService.create(request);
             menuService.display(menu.getId());
 
@@ -230,7 +223,6 @@ class MenuServiceTest {
             final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
             final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
             final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
             existingId = menuService.create(request).getId();
         }
 
@@ -279,25 +271,16 @@ class MenuServiceTest {
     @DisplayName("메뉴 조회")
     class FindAllMenus {
 
-        @BeforeEach
-        void setup() {
-            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
-            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
-            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
-            final Menu menu = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
-        }
-
         @Test
         @DisplayName("등록된 모든 메뉴의 목록을 조회한다.")
         void findAllMenusSuccess() {
             // given
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
             List<UUID> menuIds = IntStream.rangeClosed(1, 2).mapToObj(i -> {
                 final Product product = saveProduct(i, "후라이드", BigDecimal.valueOf(16_000));
                 final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
                 final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
                 final Menu menu = MenuFixture.createMenu("후라이드 치킨" + i, BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
-                return menuService.create(menu).getId();
+                return menuRepository.save(menu).getId();
             }).toList();
 
             // when
@@ -307,7 +290,7 @@ class MenuServiceTest {
             assertThat(result)
                     .hasSize(2)
                     .extracting(Menu::getId)
-                    .containsExactly(menuIds.toArray(UUID[]::new));
+                    .containsExactlyInAnyOrder(menuIds.toArray(UUID[]::new));
         }
     }
 

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -1,0 +1,237 @@
+package kitchenpos.application;
+
+import kitchenpos.domain.*;
+import kitchenpos.fixture.MenuFixture;
+import kitchenpos.fixture.MenuGroupFixture;
+import kitchenpos.fixture.MenuProductFixture;
+import kitchenpos.fixture.ProductFixture;
+import kitchenpos.infra.PurgomalumClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+class MenuServiceTest {
+
+    @Autowired
+    private MenuService menuService;
+
+    @Autowired
+    private MenuRepository menuRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private MenuGroupRepository menuGroupRepository;
+
+    @MockBean
+    private PurgomalumClient purgomalumClient;
+
+    @Nested
+    @DisplayName("메뉴 등록")
+    class RegisterMenu {
+
+        @Test
+        @DisplayName("메뉴를 등록한다.")
+        void registerMenu() {
+            // given
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
+
+            // when
+            final Menu result = menuService.create(request);
+
+            // then
+            final Menu found = menuRepository.findById(result.getId()).orElse(null);
+
+            assertThat(found).isNotNull();
+            assertAll(
+                    () -> assertThat(found.getName()).isEqualTo(request.getName()),
+                    () -> assertThat(found.getPrice()).isEqualByComparingTo(request.getPrice())
+            );
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @DisplayName("메뉴는 이름과 가격을 필수로 가진다.")
+        void nullName(final String name) {
+            // given
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu request = MenuFixture.createMenu(name, BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> menuService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @ParameterizedTest
+        @DisplayName("메뉴의 가격은 0원 이상이어야 한다.")
+        @ValueSource(ints = {-1000, -1})
+        void priceLessThanZero(final int price) {
+            // given
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu request = MenuFixture.createMenu("후라이드치킨", BigDecimal.valueOf(price), List.of(menuProduct), menuGroup);
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> menuService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("메뉴 등록 시 이름의 유해성 여부를 검사한다.")
+        void inappropriateName() {
+            // given
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu request = MenuFixture.createMenu("부적절한이름", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(true);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> menuService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 가격 변경")
+    class ChangeMenuPrice {
+        private UUID existingId;
+        private UUID nonExistingId = UUID.randomUUID();
+
+        @BeforeEach
+        void setup() {
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
+            existingId = menuService.create(request).getId();
+        }
+
+        @Test
+        @DisplayName("지정한 메뉴의 가격을 변경할 수 있다.")
+        void changeMenuPriceSuccess() {
+            // given
+            final Menu request = MenuFixture.createMenuRequest(BigDecimal.valueOf(15_000));
+
+            // when
+            final Menu result = menuService.changePrice(existingId, request);
+
+            // then
+            final Menu found = menuRepository.findById(result.getId()).orElse(null);
+            assertThat(found).isNotNull();
+            assertThat(found.getPrice()).isEqualByComparingTo(request.getPrice());
+        }
+
+        @ParameterizedTest
+        @DisplayName("메뉴 가격 변경 시 가격이 0원 이상이어야 한다.")
+        @ValueSource(ints = {-1000, -1})
+        void changeMenuPriceFailsWithNegativePrice(final int price) {
+            // given
+            final Menu request = MenuFixture.createMenuRequest(BigDecimal.valueOf(price));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> menuService.changePrice(existingId, request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("등록되지 않은 메뉴의 가격을 변경할 수 없다.")
+        void nonExistingMenu() {
+            // given
+            final Menu request = MenuFixture.createMenuRequest(BigDecimal.valueOf(15_000));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> menuService.changePrice(nonExistingId, request))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 조회")
+    class FindAllMenus {
+
+        @BeforeEach
+        void setup() {
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu menu = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
+        }
+
+        @Test
+        @DisplayName("등록된 모든 메뉴의 목록을 조회한다.")
+        void findAllMenusSuccess() {
+            // given
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
+            List<UUID> menuIds = IntStream.rangeClosed(1, 2).mapToObj(i -> {
+                final Product product = saveProduct(i, "후라이드", BigDecimal.valueOf(16_000));
+                final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+                final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+                final Menu menu = MenuFixture.createMenu("후라이드 치킨" + i, BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
+                return menuService.create(menu).getId();
+            }).toList();
+
+            // when
+            final List<Menu> result = menuService.findAll();
+
+            // then
+            assertThat(result)
+                    .hasSize(2)
+                    .extracting(Menu::getId)
+                    .containsExactly(menuIds.toArray(UUID[]::new));
+        }
+    }
+
+    private Product saveProduct(int index, String name, BigDecimal price) {
+        return productRepository.save(
+                ProductFixture.createProduct(name + index, price)
+        );
+    }
+
+    private Product saveProduct(String name, BigDecimal price) {
+        return saveProduct(0, name, price);
+    }
+
+    private MenuGroup saveMenuGroup(String name) {
+        return menuGroupRepository.save(
+                MenuGroupFixture.createMenuGroup(name)
+        );
+    }
+
+}

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -123,7 +123,100 @@ class MenuServiceTest {
                     .isThrownBy(() -> menuService.create(request))
                     .isInstanceOf(IllegalArgumentException.class);
         }
+
+        @Test
+        @DisplayName("메뉴의 가격은 지정한 상품들의 가격 총합보다 작아야 한다.")
+        void testPriceLessThanSumOfProductPrices() {
+            // given
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(17_000), List.of(menuProduct), menuGroup);
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> menuService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
     }
+
+    @Nested
+    @DisplayName("메뉴 노출")
+    class DisplayMenu {
+
+        @Test
+        @DisplayName("지정한 메뉴를 노출한다.")
+        void testDisplayMenu() {
+            // given
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
+            final Menu menu = menuService.create(request);
+
+            // when
+            final Menu result = menuService.display(menu.getId());
+
+            // then
+            assertThat(result).isNotNull();
+            assertAll(
+                    () -> assertThat(result.getId()).isEqualTo(menu.getId()),
+                    () -> assertThat(result.getName()).isEqualTo(menu.getName()),
+                    () -> assertThat(result.getPrice()).isEqualByComparingTo(menu.getPrice())
+            );
+        }
+
+        @Test
+        @DisplayName("메뉴의 가격이 메뉴에 포함된 상품들의 총합보다 작은 경우에만 노출처리할 수 있다.")
+        void testDisplayMenuWithPriceLessThanSumOfProductPrices() {
+            // given
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
+            final Menu menu = menuService.create(request);
+            menu.setPrice(BigDecimal.valueOf(17_000));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> menuService.display(menu.getId()))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 숨김")
+    class HideMenu {
+
+        @Test
+        @DisplayName("지정한 메뉴를 숨김처리한다.")
+        void testHideMenu() {
+            // given
+            final Product product = saveProduct("후라이드", BigDecimal.valueOf(16_000));
+            final MenuGroup menuGroup = saveMenuGroup("한마리메뉴");
+            final MenuProduct menuProduct = MenuProductFixture.createMenuProduct(product, 1L);
+            final Menu request = MenuFixture.createMenu("후라이드 치킨", BigDecimal.valueOf(16_000), List.of(menuProduct), menuGroup);
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
+            final Menu menu = menuService.create(request);
+            menuService.display(menu.getId());
+
+            // when
+            final Menu result = menuService.hide(menu.getId());
+
+            // then
+            assertThat(result).isNotNull();
+            assertAll(
+                    () -> assertThat(result.getId()).isEqualTo(menu.getId()),
+                    () -> assertThat(result.getName()).isEqualTo(menu.getName()),
+                    () -> assertThat(result.getPrice()).isEqualByComparingTo(menu.getPrice())
+            );
+        }
+    }
+
 
     @Nested
     @DisplayName("메뉴 가격 변경")

--- a/src/test/java/kitchenpos/application/OrderServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderServiceTest.java
@@ -1,0 +1,397 @@
+package kitchenpos.application;
+
+import kitchenpos.domain.*;
+import kitchenpos.fake.FakeKitchenridersClient;
+import kitchenpos.fixture.MenuFixture;
+import kitchenpos.fixture.OrderFixture;
+import kitchenpos.fixture.OrderTableFixture;
+import kitchenpos.infra.KitchenridersClient;
+import kitchenpos.repository.InMemoryMenuRepository;
+import kitchenpos.repository.InMemoryOrderRepository;
+import kitchenpos.repository.InMemoryOrderTableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class OrderServiceTest {
+
+    private OrderService orderService;
+
+    private OrderRepository orderRepository;
+
+    private OrderTableRepository orderTableRepository;
+
+    private MenuRepository menuRepository;
+
+    private KitchenridersClient kitchenridersClient;
+
+    @BeforeEach
+    void setup() {
+        orderRepository = new InMemoryOrderRepository();
+        orderTableRepository = new InMemoryOrderTableRepository();
+        menuRepository = new InMemoryMenuRepository();
+        kitchenridersClient = new FakeKitchenridersClient();
+        orderService = new OrderService(orderRepository, menuRepository, orderTableRepository, kitchenridersClient);
+    }
+
+    @Nested
+    @DisplayName("주문 등록")
+    class RegisterOrder {
+
+        @Test
+        @DisplayName("주문을 등록한다.")
+        void testRegisterOrder() {
+            // given
+            final Menu menu = menuRepository.save(MenuFixture.createMenu());
+            final OrderLineItem orderLineItem = OrderFixture.createOrderLineItem(menu, 1);
+            final Order request = OrderFixture.createOrderRequest(OrderType.TAKEOUT, List.of(orderLineItem));
+
+            // when
+            final Order result = orderService.create(request);
+
+            // then
+            final Order found = orderRepository.findById(result.getId()).orElse(null);
+            assertThat(found).isNotNull();
+            assertAll(
+                    () -> assertThat(found.getType()).isEqualTo(request.getType()),
+                    () -> assertThat(found.getStatus()).isEqualTo(OrderStatus.WAITING),
+                    () -> assertThat(found.getOrderLineItems()).hasSize(1)
+            );
+        }
+
+        @ParameterizedTest
+        @DisplayName("주문 유형이 배달주문이면 배달주소를 입력해야한다.")
+        @NullSource
+        void testRegisterOrderWithDeliveryAddress(final String deliveryAddress) {
+            // given
+            final Order request = OrderFixture.createDeliveryOrderRequest(deliveryAddress);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("주문 유형이 매장식사인 경우 지정한 주문테이블이 사용 중이어야 한다.")
+        void testRegisterOrderWithOrderTable() {
+            // given
+            final OrderTable orderTable = OrderTableFixture.createOrderTable();
+            final Order request = OrderFixture.createEatInOrderRequest(orderTable);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("주문 항목을 1개 이상 포함해야 한다.")
+        void testRegisterOrderWithOrderLineItems() {
+            // given
+            final List<OrderLineItem> emptyOrderLineItems = List.of();
+            final Order request = OrderFixture.createOrderRequest(OrderType.TAKEOUT, emptyOrderLineItems);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("등록된 메뉴만 주문 항목에 포함될 수 있다.")
+        void testRegisterOrderWithRegisteredMenu() {
+            // given
+            final Order request = OrderFixture.createTakeOutOrderRequest();
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = OrderType.class, names = {"DELIVERY", "TAKEOUT"})
+        @DisplayName("주문 유형이 배달이나 포장인 경우 주문한 메뉴의 수량은 반드시 1개 이상이어야 한다.")
+        void testRegisterOrderWithOrderLineItemQuantity(final OrderType orderType) {
+            // given
+            final Menu menu = menuRepository.save(MenuFixture.createMenu());
+            final OrderLineItem orderLineItem = OrderFixture.createOrderLineItem(menu, -1);
+            final Order request = OrderFixture.createOrderRequest(orderType, List.of(orderLineItem));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("노출 중이 아닌 메뉴는 주문할 수 없다.")
+        void testRegisterOrderWithVisibleMenu() {
+            // given
+            final Menu hiddenMenu = menuRepository.save(MenuFixture.createHiddenMenu());
+            final OrderLineItem orderLineItem = OrderFixture.createOrderLineItem(hiddenMenu);
+            final Order request = OrderFixture.createOrderRequest(OrderType.TAKEOUT, List.of(orderLineItem));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.create(request))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        @DisplayName("주문한 메뉴의 가격과 등록된 메뉴의 가격이 다르면 예외가 발생한다.")
+        void testRegisterOrderWithOrderLineItemPrice() {
+            // given
+            final Menu orderedMenu = menuRepository.save(MenuFixture.createMenu(BigDecimal.valueOf(10_000)));
+            menuRepository.save(MenuFixture.createMenu(BigDecimal.valueOf(16_000)));
+            final OrderLineItem orderLineItem = OrderFixture.createOrderLineItem(orderedMenu, 1, BigDecimal.valueOf(20_000));
+            final Order request = OrderFixture.createOrderRequest(OrderType.TAKEOUT, List.of(orderLineItem));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 수락")
+    class AcceptOrder {
+
+        @Test
+        @DisplayName("주문 상태를 수락(ACCEPTED)으로 변경한다.")
+        void testAcceptOrder() {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderStatus.WAITING));
+
+            // when
+            final Order result = orderService.accept(request.getId());
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(OrderStatus.ACCEPTED);
+        }
+
+        @ParameterizedTest
+        @DisplayName("대기 중인 주문이 아닌 경우 수락할 수 없다.")
+        @EnumSource(value = OrderStatus.class, names = {"ACCEPTED", "SERVED", "DELIVERING", "DELIVERED", "COMPLETED"})
+        void testAcceptOrderWithStatus(final OrderStatus status) {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(status));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.accept(request.getId()))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        @DisplayName("주문을 수락하면 배달 라이더에게 주문을 전달한다.")
+        void testAcceptOrderWithDelivery() {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderType.DELIVERY, OrderStatus.WAITING));
+
+            // when
+            final Order result = orderService.accept(request.getId());
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(OrderStatus.ACCEPTED);
+            assertThat(((FakeKitchenridersClient) kitchenridersClient).getRequestDeliveryCount()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 제공")
+    class ServeOrder {
+
+        @Test
+        @DisplayName("주문 상태를 제공(SERVED)으로 변경한다.")
+        void testServeOrder() {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderStatus.ACCEPTED));
+
+            // when
+            final Order result = orderService.serve(request.getId());
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(OrderStatus.SERVED);
+        }
+
+        @ParameterizedTest
+        @DisplayName("수락(ACCEPTED)된 주문만 변경할 수 있다.")
+        @EnumSource(value = OrderStatus.class, names = {"WAITING", "SERVED", "DELIVERING", "DELIVERED", "COMPLETED"})
+        void testServeOrderWithStatus(final OrderStatus status) {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(status));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.serve(request.getId()))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 배달 시작")
+    class DeliveryOrder {
+
+        @Test
+        @DisplayName("주문 상태를 배달중(DELIVERING)으로 변경한다.")
+        void testDeliveryOrder() {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderStatus.SERVED));
+
+            // when
+            final Order result = orderService.startDelivery(request.getId());
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(OrderStatus.DELIVERING);
+        }
+
+        @ParameterizedTest
+        @DisplayName("주문 유형이 배달주문이 아니면 오류가 발생한다.")
+        @EnumSource(value = OrderType.class, names = {"DELIVERY", "TAKEOUT"})
+        void testDeliveryOrderWithOrderType(final OrderType orderType) {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrderRequest(orderType, List.of(OrderFixture.createOrderLineItem())));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.startDelivery(request.getId()))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+
+        @ParameterizedTest
+        @DisplayName("수락(SERVED)된 주문만 배달할 수 있다.")
+        @EnumSource(value = OrderStatus.class, names = {"WAITING", "ACCEPTED", "DELIVERING", "DELIVERED", "COMPLETED"})
+        void testDeliveryOrderWithStatus(final OrderStatus status) {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(status));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.startDelivery(request.getId()))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 배달 완료")
+    class CompleteDelivery {
+
+        @Test
+        @DisplayName("주문 상태를 배달완료(DELIVERED)으로 변경한다.")
+        void testCompleteDelivery() {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderStatus.DELIVERING));
+
+            // when
+            final Order result = orderService.completeDelivery(request.getId());
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(OrderStatus.DELIVERED);
+        }
+
+        @ParameterizedTest
+        @DisplayName("배달중(DELIVERING)인 주문만 배달 완료할 수 있다.")
+        @EnumSource(value = OrderStatus.class, names = {"WAITING", "ACCEPTED", "SERVED", "DELIVERED", "COMPLETED"})
+        void testCompleteDeliveryWithStatus(final OrderStatus status) {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(status));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.completeDelivery(request.getId()))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 완료")
+    class CompleteOrder {
+
+        @Test
+        @DisplayName("주문 상태를 완료(COMPLETED)로 변경한다.")
+        void testCompleteOrder() {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderType.DELIVERY, OrderStatus.DELIVERED));
+
+            // when
+            final Order result = orderService.complete(request.getId());
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(OrderStatus.COMPLETED);
+        }
+
+        @ParameterizedTest
+        @DisplayName("주문 유형이 배달주문이면 배달완료(DELIVERED) 상태일 경우에만 변경할 수 있다.")
+        @EnumSource(value = OrderStatus.class, names = {"WAITING", "ACCEPTED", "SERVED", "DELIVERING", "COMPLETED"})
+        void testCompleteOrderWithStatus(final OrderStatus status) {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderType.DELIVERY, status));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.complete(request.getId()))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @ParameterizedTest
+        @DisplayName("주문 유형이 포장주문인 경우 제공완료(SERVED) 상태일 경우에만 변경할 수 있다.")
+        @EnumSource(value = OrderStatus.class, names = {"WAITING", "ACCEPTED", "DELIVERING", "DELIVERED", "COMPLETED"})
+        void testCompleteOrderWithTakeOut(final OrderStatus status) {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderType.TAKEOUT, status));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.complete(request.getId()))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @ParameterizedTest
+        @DisplayName("주문 유형이 매장식사인 경우 제공완료(SERVED) 상태일 경우에만 변경할 수 있다.")
+        @EnumSource(value = OrderStatus.class, names = {"WAITING", "ACCEPTED", "DELIVERING", "DELIVERED", "COMPLETED"})
+        void testCompleteOrderWithDeliveryAndTakeOut(final OrderStatus status) {
+            // given
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderType.EAT_IN, status));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderService.complete(request.getId()))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        @DisplayName("주문 유형이 매장식사일 때 주문 테이블을 정리한다.")
+        void testCompleteOrderWithOrderTable() {
+            // given
+            final Menu menu = menuRepository.save(MenuFixture.createMenu());
+            final OrderLineItem orderLineItem = OrderFixture.createOrderLineItem(menu, 1);
+            final OrderTable orderTable = OrderTableFixture.createOrderTable();
+            final Order request = orderRepository.save(OrderFixture.createOrder(OrderStatus.SERVED, orderTable, List.of(orderLineItem)));
+
+            // when
+            final Order result = orderService.complete(request.getId());
+
+            // then
+            assertAll(
+                    () -> assertThat(result.getOrderTable().getNumberOfGuests()).isZero(),
+                    () -> assertThat(result.getOrderTable().isOccupied()).isFalse()
+            );
+        }
+    }
+
+}

--- a/src/test/java/kitchenpos/application/OrderTableServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderTableServiceTest.java
@@ -1,0 +1,176 @@
+package kitchenpos.application;
+
+import kitchenpos.domain.OrderRepository;
+import kitchenpos.domain.OrderTable;
+import kitchenpos.domain.OrderTableRepository;
+import kitchenpos.fixture.OrderTableFixture;
+import kitchenpos.repository.InMemoryOrderRepository;
+import kitchenpos.repository.InMemoryOrderTableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class OrderTableServiceTest {
+
+    private OrderTableService orderTableService;
+
+    private OrderTableRepository orderTableRepository;
+
+    private OrderRepository orderRepository;
+
+    @BeforeEach
+    void setUp() {
+        orderTableRepository = new InMemoryOrderTableRepository();
+        orderRepository = new InMemoryOrderRepository();
+        orderTableService = new OrderTableService(orderTableRepository, orderRepository);
+    }
+
+    @Nested
+    @DisplayName("주문 테이블 등록")
+    class CreateOrderTable {
+
+        @Test
+        @DisplayName("이름으로 주문 테이블을 생성한다.")
+        void createOrderTable() {
+            // given
+            final OrderTable request = OrderTableFixture.createOrderTableRequest("테이블1", 0, false);
+
+            // when
+            final OrderTable result = orderTableService.create(request);
+
+            // then
+            final OrderTable found = orderTableRepository.findById(result.getId()).orElse(null);
+            assertThat(found).isNotNull();
+            assertAll(
+                    () -> assertThat(found.getName()).isEqualTo(request.getName()),
+                    () -> assertThat(found.getNumberOfGuests()).isEqualTo(request.getNumberOfGuests()),
+                    () -> assertThat(found.isOccupied()).isFalse()
+            );
+
+        }
+    }
+
+    @Nested
+    @DisplayName("착석")
+    class SitOrderTable {
+
+        @Test
+        @DisplayName("주문 테이블을 사용중으로 변경한다.")
+        void sitOrderTable() {
+            // given
+            final OrderTable request = OrderTableFixture.createOrderTableRequest("테이블1", 0, false);
+            final OrderTable orderTable = orderTableRepository.save(request);
+
+            // when
+            final OrderTable result = orderTableService.sit(orderTable.getId());
+
+            // then
+            final OrderTable found = orderTableRepository.findById(result.getId()).orElse(null);
+            assertThat(found).isNotNull();
+            assertThat(found.isOccupied()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("정리")
+    class ClearOrderTable {
+
+        @Test
+        @DisplayName("주문 테이블을 미사용으로 변경하고 손님수를 0명으로 설정한다.")
+        void clearOrderTable() {
+            // given
+            final OrderTable request = OrderTableFixture.createOrderTableRequest("테이블1", 0, false);
+            final OrderTable orderTable = orderTableRepository.save(request);
+
+            // when
+            final OrderTable result = orderTableService.clear(orderTable.getId());
+
+            // then
+            final OrderTable found = orderTableRepository.findById(result.getId()).orElse(null);
+            assertThat(found.isOccupied()).isFalse();
+            assertThat(found.getNumberOfGuests()).isZero();
+        }
+
+        @Test
+        @DisplayName("현재 주문 테이블의 모든 주문이 완료(COMPLETED)되면 정리할 수 있다.")
+        void clearOrderTableWithCompletedOrders() {
+            // given
+            final OrderTable request = OrderTableFixture.createOrderTableRequest("테이블1", 0, false);
+            final OrderTable orderTable = orderTableRepository.save(request);
+
+            // when
+            final OrderTable result = orderTableService.clear(orderTable.getId());
+
+            // then
+            final OrderTable found = orderTableRepository.findById(result.getId()).orElse(null);
+            assertThat(found.isOccupied()).isFalse();
+            assertThat(found.getNumberOfGuests()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("손님수 변경")
+    class ChangeNumberOfGuests {
+
+        @Test
+        @DisplayName("손님 수는 0명 이상이어야 한다.")
+        void changeNumberOfGuests() {
+            // given
+            final OrderTable orderTable = orderTableRepository.save(OrderTableFixture.createOrderTable("테이블1", 0, true));
+            final OrderTable request = new OrderTable();
+            request.setNumberOfGuests(3);
+
+            // when
+            final OrderTable result = orderTableService.changeNumberOfGuests(orderTable.getId(), request);
+
+            // then
+            final OrderTable found = orderTableRepository.findById(result.getId()).orElse(null);
+            assertThat(found).isNotNull();
+            assertThat(found.getNumberOfGuests()).isEqualTo(request.getNumberOfGuests());
+        }
+
+        @Test
+        @DisplayName("미사용인 주문 테이블만 변경할 수 있다.")
+        void changeNumberOfGuestsForNonOccupiedTable() {
+            // given
+            final OrderTable orderTable = orderTableRepository.save(OrderTableFixture.createOrderTable("테이블1", 0, false));
+            final OrderTable request = new OrderTable();
+            request.setNumberOfGuests(3);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> orderTableService.changeNumberOfGuests(orderTable.getId(), request))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 테이블 조회")
+    class FindAllOrderTables {
+
+        @Test
+        @DisplayName("모든 주문 테이블 목록을 조회한다.")
+        void findAllOrderTables() {
+            // given
+            OrderTable orderTable1 = orderTableRepository.save(OrderTableFixture.createOrderTable("테이블1", 0, false));
+            OrderTable orderTable2 = orderTableRepository.save(OrderTableFixture.createOrderTable("테이블2", 0, false));
+
+            // when
+            final List<OrderTable> result = orderTableService.findAll();
+
+            // then
+            assertThat(result)
+                    .hasSize(2)
+                    .extracting(OrderTable::getId)
+                    .containsExactlyInAnyOrder(orderTable1.getId(), orderTable2.getId());
+        }
+    }
+
+}

--- a/src/test/java/kitchenpos/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/application/ProductServiceTest.java
@@ -8,11 +8,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -26,20 +24,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
-@ExtendWith(MockitoExtension.class)
 class ProductServiceTest {
-
-    @MockBean
-    private PurgomalumClient purgomalumClient;
 
     @Autowired
     private ProductService productService;
 
     @Autowired
     private ProductRepository productRepository;
+
+    @MockBean
+    private PurgomalumClient purgomalumClient;
 
     @Nested
     @DisplayName("상품 등록")
@@ -49,10 +46,8 @@ class ProductServiceTest {
         @DisplayName("상품을 등록한다.")
         void testRegisterProduct() {
             // given
-            final String name = "PRODUCT_NAME";
-            final BigDecimal price = BigDecimal.valueOf(1000);
-            final Product request = ProductFixture.createProduct(name, price);
-            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
+            final Product request = ProductFixture.createProductRequest("후라이드", BigDecimal.valueOf(16_000));
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when
             final Product result = productService.create(request);
@@ -62,18 +57,18 @@ class ProductServiceTest {
 
             assertThat(found).isNotNull();
             assertAll(
-                    () -> assertThat(found.getName()).isEqualTo(name),
-                    () -> assertThat(found.getPrice()).isEqualByComparingTo(price)
+                    () -> assertThat(found.getName()).isEqualTo(request.getName()),
+                    () -> assertThat(found.getPrice()).isEqualByComparingTo(request.getPrice())
             );
         }
 
         @ParameterizedTest
-        @NullAndEmptySource
+        @NullSource
         @DisplayName("상품은 이름과 가격을 필수로 가진다.")
-        void testNullOrEmptyName(final String name) {
+        void testNullName(final String name) {
             // given
-            final Product request = ProductFixture.createProduct(name, BigDecimal.valueOf(1000));
-            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
+            final Product request = ProductFixture.createProductRequest(name, BigDecimal.valueOf(16_000));
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when & then
             assertThatException()
@@ -86,8 +81,8 @@ class ProductServiceTest {
         @ValueSource(ints = {-1000, -1})
         void testPriceLessThanZero(final int price) {
             // given
-            final Product request = ProductFixture.createProduct("VALID_NAME", BigDecimal.valueOf(price));
-            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
+            final Product request = ProductFixture.createProduct("후라이드", BigDecimal.valueOf(price));
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when & then
             assertThatException()
@@ -99,8 +94,8 @@ class ProductServiceTest {
         @DisplayName("상품 등록 시 이름의 유해성 여부를 검사한다.")
         void testInappropriateName() {
             // given
-            final Product request = ProductFixture.createProduct("INAPPROPRIATE_NAME", BigDecimal.valueOf(1000));
-            when(purgomalumClient.containsProfanity(anyString())).thenReturn(true);
+            final Product request = ProductFixture.createProduct("부적절한이름", BigDecimal.valueOf(1000));
+            given(purgomalumClient.containsProfanity(anyString())).willReturn(true);
 
             // when & then
             assertThatException()
@@ -117,33 +112,31 @@ class ProductServiceTest {
 
         @BeforeEach
         void setup() {
-            final Product product = ProductFixture.createProduct("PRODUCT_NAME", BigDecimal.valueOf(1000));
-            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
-            existingId = productService.create(product).getId();
+            existingId = saveProduct().getId();
         }
 
         @Test
         @DisplayName("지정한 상품의 가격을 변경할 수 있다.")
         void changeProductPriceSuccess() {
             // given
-            final Product request = new Product();
-            request.setPrice(BigDecimal.valueOf(2000));
+            final Product request = ProductFixture.createProductRequest("후라이드", BigDecimal.valueOf(20_000));
 
             // when
             final Product result = productService.changePrice(existingId, request);
 
             // then
-            assertThat(result).isNotNull();
-            assertThat(result.getPrice()).isEqualTo(BigDecimal.valueOf(2000));
+            final Product found = productRepository.findById(result.getId()).orElse(null);
+
+            assertThat(found).isNotNull();
+            assertThat(found.getPrice()).isEqualByComparingTo(request.getPrice());
         }
 
         @ParameterizedTest
         @DisplayName("상품 가격 변경 시 가격이 0원 이상이어야 한다.")
         @ValueSource(ints = {-1000, -1})
-        void changeProductPriceFailsWithNegativePrice() {
+        void changeProductPriceFailsWithNegativePrice(final int price) {
             // given
-            final Product request = new Product();
-            request.setPrice(BigDecimal.valueOf(-2000));
+            final Product request = ProductFixture.createProductRequest("후라이드", BigDecimal.valueOf(price));
 
             // when & then
             assertThatException()
@@ -155,8 +148,7 @@ class ProductServiceTest {
         @DisplayName("등록되지 않은 상품의 가격을 변경할 수 없다.")
         void testNonExistingProduct() {
             // given
-            final Product request = new Product();
-            request.setPrice(BigDecimal.valueOf(2000));
+            final Product request = ProductFixture.createProductRequest("후라이드", BigDecimal.valueOf(20_000));
 
             // when & then
             assertThatException()
@@ -173,11 +165,7 @@ class ProductServiceTest {
         @DisplayName("등록된 모든 상품의 목록을 조회한다.")
         void findAllProductsSuccess() {
             // given
-            final Product product1 = ProductFixture.createProduct("PRODUCT_1", BigDecimal.valueOf(1000));
-            final Product product2 = ProductFixture.createProduct("PRODUCT_2", BigDecimal.valueOf(2000));
-            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
-            productService.create(product1);
-            productService.create(product2);
+            List<UUID> ids = List.of(saveProduct(1).getId(), saveProduct(2).getId());
 
             // when
             final List<Product> result = productService.findAll();
@@ -185,9 +173,18 @@ class ProductServiceTest {
             // then
             assertThat(result)
                     .hasSize(2)
-                    .extracting(Product::getName)
-                    .containsExactly("PRODUCT_1", "PRODUCT_2");
+                    .extracting(Product::getId)
+                    .containsExactly(ids.toArray(UUID[]::new));
         }
+    }
+
+    private Product saveProduct(int index) {
+        final Product product = ProductFixture.createProduct("후라이드%d".formatted(index) + index, BigDecimal.valueOf(16_000));
+        return productRepository.save(product);
+    }
+
+    private Product saveProduct() {
+        return saveProduct(1);
     }
 
 }

--- a/src/test/java/kitchenpos/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/application/ProductServiceTest.java
@@ -1,0 +1,200 @@
+package kitchenpos.application;
+
+import kitchenpos.domain.Product;
+import kitchenpos.domain.ProductRepository;
+import kitchenpos.infra.PurgomalumClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @MockBean
+    private PurgomalumClient purgomalumClient;
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Nested
+    @DisplayName("상품 등록")
+    class RegisterProduct {
+
+        @Test
+        @DisplayName("상품을 등록한다.")
+        void testRegisterProduct() {
+            // given
+            final String name = "PRODUCT_NAME";
+            final BigDecimal price = BigDecimal.valueOf(1000);
+            final Product request = createProduct(name, price);
+            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
+
+            // when
+            final Product result = productService.create(request);
+
+            // then
+            final Product found = productRepository.findById(result.getId()).orElse(null);
+
+            assertThat(found).isNotNull();
+            assertAll(
+                    () -> assertThat(found.getName()).isEqualTo(name),
+                    () -> assertThat(found.getPrice()).isEqualByComparingTo(price)
+            );
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @DisplayName("상품은 이름과 가격을 필수로 가진다.")
+        void testNullOrEmptyName(final String name) {
+            // given
+            final Product request = createProduct(name, BigDecimal.valueOf(1000));
+            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> productService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @ParameterizedTest
+        @DisplayName("상품의 가격은 0원 이상이어야 한다.")
+        @ValueSource(ints = {-1000, -1})
+        void testPriceLessThanZero(final int price) {
+            // given
+            final Product request = createProduct("VALID_NAME", BigDecimal.valueOf(price));
+            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> productService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("상품 등록 시 이름의 유해성 여부를 검사한다.")
+        void testInappropriateName() {
+            // given
+            final Product request = createProduct("INAPPROPRIATE_NAME", BigDecimal.valueOf(1000));
+            when(purgomalumClient.containsProfanity(anyString())).thenReturn(true);
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> productService.create(request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 가격 변경")
+    class ChangeProductPrice {
+        UUID existingId;
+        UUID nonExistingId = UUID.randomUUID();
+
+        @BeforeEach
+        void setup() {
+            final Product product = createProduct("PRODUCT_NAME", BigDecimal.valueOf(1000));
+            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
+            existingId = productService.create(product).getId();
+        }
+
+        @Test
+        @DisplayName("지정한 상품의 가격을 변경할 수 있다.")
+        void changeProductPriceSuccess() {
+            // given
+            final Product request = new Product();
+            request.setPrice(BigDecimal.valueOf(2000));
+
+            // when
+            final Product result = productService.changePrice(existingId, request);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getPrice()).isEqualTo(BigDecimal.valueOf(2000));
+        }
+
+        @ParameterizedTest
+        @DisplayName("상품 가격 변경 시 가격이 0원 이상이어야 한다.")
+        @ValueSource(ints = {-1000, -1})
+        void changeProductPriceFailsWithNegativePrice() {
+            // given
+            final Product request = new Product();
+            request.setPrice(BigDecimal.valueOf(-2000));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> productService.changePrice(existingId, request))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("등록되지 않은 상품의 가격을 변경할 수 없다.")
+        void testNonExistingProduct() {
+            // given
+            final Product request = new Product();
+            request.setPrice(BigDecimal.valueOf(2000));
+
+            // when & then
+            assertThatException()
+                    .isThrownBy(() -> productService.changePrice(nonExistingId, request))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 조회")
+    class FindAllProducts {
+
+        @Test
+        @DisplayName("등록된 모든 상품의 목록을 조회한다.")
+        void findAllProductsSuccess() {
+            // given
+            final Product product1 = createProduct("PRODUCT_1", BigDecimal.valueOf(1000));
+            final Product product2 = createProduct("PRODUCT_2", BigDecimal.valueOf(2000));
+            when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
+            productService.create(product1);
+            productService.create(product2);
+
+            // when
+            final List<Product> result = productService.findAll();
+
+            // then
+            assertThat(result)
+                    .hasSize(2)
+                    .extracting(Product::getName)
+                    .containsExactly("PRODUCT_1", "PRODUCT_2");
+        }
+    }
+
+    private Product createProduct(final String name, final BigDecimal price) {
+        final Product product = new Product();
+        product.setId(UUID.randomUUID());
+        product.setName(name);
+        product.setPrice(price);
+        return product;
+    }
+
+}

--- a/src/test/java/kitchenpos/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/application/ProductServiceTest.java
@@ -2,6 +2,7 @@ package kitchenpos.application;
 
 import kitchenpos.domain.Product;
 import kitchenpos.domain.ProductRepository;
+import kitchenpos.fixture.ProductFixture;
 import kitchenpos.infra.PurgomalumClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -50,7 +51,7 @@ class ProductServiceTest {
             // given
             final String name = "PRODUCT_NAME";
             final BigDecimal price = BigDecimal.valueOf(1000);
-            final Product request = createProduct(name, price);
+            final Product request = ProductFixture.createProduct(name, price);
             when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
 
             // when
@@ -71,7 +72,7 @@ class ProductServiceTest {
         @DisplayName("상품은 이름과 가격을 필수로 가진다.")
         void testNullOrEmptyName(final String name) {
             // given
-            final Product request = createProduct(name, BigDecimal.valueOf(1000));
+            final Product request = ProductFixture.createProduct(name, BigDecimal.valueOf(1000));
             when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
 
             // when & then
@@ -85,7 +86,7 @@ class ProductServiceTest {
         @ValueSource(ints = {-1000, -1})
         void testPriceLessThanZero(final int price) {
             // given
-            final Product request = createProduct("VALID_NAME", BigDecimal.valueOf(price));
+            final Product request = ProductFixture.createProduct("VALID_NAME", BigDecimal.valueOf(price));
             when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
 
             // when & then
@@ -98,7 +99,7 @@ class ProductServiceTest {
         @DisplayName("상품 등록 시 이름의 유해성 여부를 검사한다.")
         void testInappropriateName() {
             // given
-            final Product request = createProduct("INAPPROPRIATE_NAME", BigDecimal.valueOf(1000));
+            final Product request = ProductFixture.createProduct("INAPPROPRIATE_NAME", BigDecimal.valueOf(1000));
             when(purgomalumClient.containsProfanity(anyString())).thenReturn(true);
 
             // when & then
@@ -116,7 +117,7 @@ class ProductServiceTest {
 
         @BeforeEach
         void setup() {
-            final Product product = createProduct("PRODUCT_NAME", BigDecimal.valueOf(1000));
+            final Product product = ProductFixture.createProduct("PRODUCT_NAME", BigDecimal.valueOf(1000));
             when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
             existingId = productService.create(product).getId();
         }
@@ -172,8 +173,8 @@ class ProductServiceTest {
         @DisplayName("등록된 모든 상품의 목록을 조회한다.")
         void findAllProductsSuccess() {
             // given
-            final Product product1 = createProduct("PRODUCT_1", BigDecimal.valueOf(1000));
-            final Product product2 = createProduct("PRODUCT_2", BigDecimal.valueOf(2000));
+            final Product product1 = ProductFixture.createProduct("PRODUCT_1", BigDecimal.valueOf(1000));
+            final Product product2 = ProductFixture.createProduct("PRODUCT_2", BigDecimal.valueOf(2000));
             when(purgomalumClient.containsProfanity(anyString())).thenReturn(false);
             productService.create(product1);
             productService.create(product2);
@@ -187,14 +188,6 @@ class ProductServiceTest {
                     .extracting(Product::getName)
                     .containsExactly("PRODUCT_1", "PRODUCT_2");
         }
-    }
-
-    private Product createProduct(final String name, final BigDecimal price) {
-        final Product product = new Product();
-        product.setId(UUID.randomUUID());
-        product.setName(name);
-        product.setPrice(price);
-        return product;
     }
 
 }

--- a/src/test/java/kitchenpos/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/application/ProductServiceTest.java
@@ -1,9 +1,13 @@
 package kitchenpos.application;
 
+import kitchenpos.domain.MenuRepository;
 import kitchenpos.domain.Product;
 import kitchenpos.domain.ProductRepository;
+import kitchenpos.fake.FakePurgomalumClient;
 import kitchenpos.fixture.ProductFixture;
 import kitchenpos.infra.PurgomalumClient;
+import kitchenpos.repository.InMemoryMenuRepository;
+import kitchenpos.repository.InMemoryProductRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,9 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -23,20 +24,24 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 
-@SpringBootTest
 class ProductServiceTest {
 
-    @Autowired
     private ProductService productService;
 
-    @Autowired
     private ProductRepository productRepository;
 
-    @MockBean
+    private MenuRepository menuRepository;
+
     private PurgomalumClient purgomalumClient;
+
+    @BeforeEach
+    void setUp() {
+        productRepository = new InMemoryProductRepository();
+        menuRepository = new InMemoryMenuRepository();
+        purgomalumClient = new FakePurgomalumClient();
+        productService = new ProductService(productRepository, menuRepository, purgomalumClient);
+    }
 
     @Nested
     @DisplayName("상품 등록")
@@ -47,7 +52,6 @@ class ProductServiceTest {
         void testRegisterProduct() {
             // given
             final Product request = ProductFixture.createProductRequest("후라이드", BigDecimal.valueOf(16_000));
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when
             final Product result = productService.create(request);
@@ -68,7 +72,6 @@ class ProductServiceTest {
         void testNullName(final String name) {
             // given
             final Product request = ProductFixture.createProductRequest(name, BigDecimal.valueOf(16_000));
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when & then
             assertThatException()
@@ -82,7 +85,6 @@ class ProductServiceTest {
         void testPriceLessThanZero(final int price) {
             // given
             final Product request = ProductFixture.createProduct("후라이드", BigDecimal.valueOf(price));
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(false);
 
             // when & then
             assertThatException()
@@ -95,7 +97,6 @@ class ProductServiceTest {
         void testInappropriateName() {
             // given
             final Product request = ProductFixture.createProduct("부적절한이름", BigDecimal.valueOf(1000));
-            given(purgomalumClient.containsProfanity(anyString())).willReturn(true);
 
             // when & then
             assertThatException()
@@ -174,7 +175,7 @@ class ProductServiceTest {
             assertThat(result)
                     .hasSize(2)
                     .extracting(Product::getId)
-                    .containsExactly(ids.toArray(UUID[]::new));
+                    .containsExactlyInAnyOrder(ids.toArray(UUID[]::new));
         }
     }
 

--- a/src/test/java/kitchenpos/fake/FakeKitchenridersClient.java
+++ b/src/test/java/kitchenpos/fake/FakeKitchenridersClient.java
@@ -1,0 +1,21 @@
+package kitchenpos.fake;
+
+import kitchenpos.infra.KitchenridersClient;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public class FakeKitchenridersClient implements KitchenridersClient {
+
+    private int requestDeliveryCount = 0;
+
+    @Override
+    public void requestDelivery(UUID orderId, BigDecimal amount, String deliveryAddress) {
+        requestDeliveryCount++;
+    }
+
+    public int getRequestDeliveryCount() {
+        return requestDeliveryCount;
+    }
+
+}

--- a/src/test/java/kitchenpos/fake/FakePurgomalumClient.java
+++ b/src/test/java/kitchenpos/fake/FakePurgomalumClient.java
@@ -1,0 +1,21 @@
+package kitchenpos.fake;
+
+import kitchenpos.infra.PurgomalumClient;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FakePurgomalumClient implements PurgomalumClient {
+
+    private static final List<String> profanities;
+
+    static {
+        profanities = Arrays.asList("부적절한이름", "욕설");
+    }
+
+    @Override
+    public boolean containsProfanity(final String text) {
+        return profanities.stream()
+                .anyMatch(text::contains);
+    }
+}

--- a/src/test/java/kitchenpos/fixture/MenuFixture.java
+++ b/src/test/java/kitchenpos/fixture/MenuFixture.java
@@ -1,0 +1,32 @@
+package kitchenpos.fixture;
+
+import kitchenpos.domain.Menu;
+import kitchenpos.domain.MenuGroup;
+import kitchenpos.domain.MenuProduct;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public class MenuFixture {
+
+
+    public static Menu createMenu(final String name, final BigDecimal price, final List<MenuProduct> menuProducts, final MenuGroup menuGroup) {
+        Menu menu = new Menu();
+        menu.setId(UUID.randomUUID());
+        menu.setName(name);
+        menu.setPrice(price);
+        menu.setMenuProducts(menuProducts);
+        menu.setMenuGroup(menuGroup);
+        menu.setMenuGroupId(menuGroup.getId());
+        menu.setDisplayed(false);
+        return menu;
+    }
+
+    public static Menu createMenuRequest(final BigDecimal price) {
+        Menu menu = new Menu();
+        menu.setPrice(price);
+        return menu;
+    }
+
+}

--- a/src/test/java/kitchenpos/fixture/MenuFixture.java
+++ b/src/test/java/kitchenpos/fixture/MenuFixture.java
@@ -19,8 +19,24 @@ public class MenuFixture {
         menu.setMenuProducts(menuProducts);
         menu.setMenuGroup(menuGroup);
         menu.setMenuGroupId(menuGroup.getId());
+        menu.setDisplayed(true);
+        return menu;
+    }
+
+    public static Menu createMenu() {
+        return createMenu(BigDecimal.valueOf(16_000));
+    }
+
+    public static Menu createHiddenMenu() {
+        Menu menu = createMenu(BigDecimal.valueOf(16_000));
         menu.setDisplayed(false);
         return menu;
+    }
+
+    public static Menu createMenu(final BigDecimal price) {
+        final MenuGroup menuGroup = MenuGroupFixture.createMenuGroup("한마리메뉴");
+        final MenuProduct menuProduct = MenuProductFixture.createMenuProduct();
+        return createMenu("후라이드치킨", price, List.of(menuProduct), menuGroup);
     }
 
     public static Menu createMenuRequest(final BigDecimal price) {

--- a/src/test/java/kitchenpos/fixture/MenuGroupFixture.java
+++ b/src/test/java/kitchenpos/fixture/MenuGroupFixture.java
@@ -1,0 +1,16 @@
+package kitchenpos.fixture;
+
+import kitchenpos.domain.MenuGroup;
+
+import java.util.UUID;
+
+public class MenuGroupFixture {
+
+    public static MenuGroup createMenuGroup(final String name) {
+        final MenuGroup menuGroup = new MenuGroup();
+        menuGroup.setId(UUID.randomUUID());
+        menuGroup.setName(name);
+        return menuGroup;
+    }
+
+}

--- a/src/test/java/kitchenpos/fixture/MenuProductFixture.java
+++ b/src/test/java/kitchenpos/fixture/MenuProductFixture.java
@@ -1,0 +1,16 @@
+package kitchenpos.fixture;
+
+import kitchenpos.domain.MenuProduct;
+import kitchenpos.domain.Product;
+
+public class MenuProductFixture {
+
+    public static MenuProduct createMenuProduct(final Product product, final long quantity) {
+        MenuProduct menuProduct = new MenuProduct();
+        menuProduct.setProduct(product);
+        menuProduct.setProductId(product.getId());
+        menuProduct.setQuantity(quantity);
+        return menuProduct;
+    }
+
+}

--- a/src/test/java/kitchenpos/fixture/MenuProductFixture.java
+++ b/src/test/java/kitchenpos/fixture/MenuProductFixture.java
@@ -3,6 +3,8 @@ package kitchenpos.fixture;
 import kitchenpos.domain.MenuProduct;
 import kitchenpos.domain.Product;
 
+import java.math.BigDecimal;
+
 public class MenuProductFixture {
 
     public static MenuProduct createMenuProduct(final Product product, final long quantity) {
@@ -11,6 +13,11 @@ public class MenuProductFixture {
         menuProduct.setProductId(product.getId());
         menuProduct.setQuantity(quantity);
         return menuProduct;
+    }
+
+    public static MenuProduct createMenuProduct() {
+        final Product product = ProductFixture.createProduct("후라이드", BigDecimal.valueOf(16000));
+        return createMenuProduct(product, 1);
     }
 
 }

--- a/src/test/java/kitchenpos/fixture/OrderFixture.java
+++ b/src/test/java/kitchenpos/fixture/OrderFixture.java
@@ -1,0 +1,100 @@
+package kitchenpos.fixture;
+
+import kitchenpos.domain.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public class OrderFixture {
+
+    public static Order createOrder(final OrderType type, final OrderStatus status, final List<OrderLineItem> orderLineItems, final String deliveryAddress, final OrderTable orderTable) {
+        Order order = new Order();
+        order.setId(UUID.randomUUID());
+        order.setType(type);
+        order.setStatus(status);
+        order.setOrderLineItems(orderLineItems);
+        order.setDeliveryAddress(deliveryAddress);
+        order.setOrderTable(orderTable);
+        order.setOrderTableId(orderTable.getId());
+        return order;
+    }
+
+    public static Order createOrder(final OrderType type, final OrderStatus status, final List<OrderLineItem> orderLineItems, final String deliveryAddress) {
+        Order order = new Order();
+        order.setId(UUID.randomUUID());
+        order.setType(type);
+        order.setStatus(status);
+        order.setOrderLineItems(orderLineItems);
+        order.setDeliveryAddress(deliveryAddress);
+        return order;
+    }
+
+    public static Order createOrder(final OrderStatus status) {
+        return createOrder(OrderType.DELIVERY, status);
+    }
+
+    public static Order createOrder(final OrderType orderType, final OrderStatus status) {
+        return createOrder(orderType, status, List.of(createOrderLineItem()), "서울시 강남구 역삼동");
+    }
+
+    public static Order createOrder(final OrderStatus status, final OrderTable orderTable, final List<OrderLineItem> orderLineItems) {
+        return createOrder(OrderType.EAT_IN, status, orderLineItems, null, orderTable);
+    }
+
+    public static Order createOrderRequest(final OrderType orderType, final List<OrderLineItem> orderLineItems) {
+        Order order = new Order();
+        order.setType(orderType);
+        order.setOrderLineItems(orderLineItems);
+        return order;
+    }
+
+    public static Order createOrderRequest(final OrderType orderType, final List<OrderLineItem> orderLineItems, final OrderTable orderTable) {
+        Order order = new Order();
+        order.setType(orderType);
+        order.setOrderLineItems(orderLineItems);
+        order.setOrderTable(orderTable);
+        return order;
+    }
+
+    public static Order createDeliveryOrderRequest(final String deliveryAddress) {
+        Order order = createOrderRequest(OrderType.DELIVERY, List.of(createOrderLineItem()));
+        order.setDeliveryAddress(deliveryAddress);
+        return order;
+    }
+
+    public static Order createEatInOrderRequest(final OrderTable orderTable) {
+        return createOrderRequest(OrderType.EAT_IN, List.of(createOrderLineItem()), orderTable);
+    }
+
+    public static Order createTakeOutOrderRequest() {
+        return createOrderRequest(OrderType.TAKEOUT, List.of(createOrderLineItem()));
+    }
+
+    public static OrderLineItem createOrderLineItem(final Menu menu, final long quantity) {
+        final OrderLineItem orderLineItem = new OrderLineItem();
+        orderLineItem.setMenuId(menu.getId());
+        orderLineItem.setQuantity(quantity);
+        orderLineItem.setMenu(menu);
+        orderLineItem.setPrice(menu.getPrice());
+        return orderLineItem;
+    }
+
+    public static OrderLineItem createOrderLineItem(final Menu menu, final long quantity, final BigDecimal price) {
+        final OrderLineItem orderLineItem = new OrderLineItem();
+        orderLineItem.setMenuId(menu.getId());
+        orderLineItem.setQuantity(quantity);
+        orderLineItem.setMenu(menu);
+        orderLineItem.setPrice(price);
+        return orderLineItem;
+    }
+
+    public static OrderLineItem createOrderLineItem(final Menu menu) {
+        return createOrderLineItem(menu, 1L);
+    }
+
+    public static OrderLineItem createOrderLineItem() {
+        return createOrderLineItem(MenuFixture.createMenu(), 1L);
+    }
+
+}

--- a/src/test/java/kitchenpos/fixture/OrderTableFixture.java
+++ b/src/test/java/kitchenpos/fixture/OrderTableFixture.java
@@ -1,0 +1,26 @@
+package kitchenpos.fixture;
+
+import kitchenpos.domain.OrderTable;
+
+import java.util.UUID;
+
+public class OrderTableFixture {
+
+    public static OrderTable createOrderTable(final String name, final int numberOfGuests, final boolean occupied) {
+        final OrderTable orderTable = new OrderTable();
+        orderTable.setId(UUID.randomUUID());
+        orderTable.setName(name);
+        orderTable.setNumberOfGuests(numberOfGuests);
+        orderTable.setOccupied(occupied);
+        return orderTable;
+    }
+
+    public static OrderTable createOrderTableRequest(final String name, final int numberOfGuests, final boolean occupied) {
+        final OrderTable orderTable = new OrderTable();
+        orderTable.setName(name);
+        orderTable.setNumberOfGuests(numberOfGuests);
+        orderTable.setOccupied(occupied);
+        return orderTable;
+    }
+
+}

--- a/src/test/java/kitchenpos/fixture/OrderTableFixture.java
+++ b/src/test/java/kitchenpos/fixture/OrderTableFixture.java
@@ -15,6 +15,18 @@ public class OrderTableFixture {
         return orderTable;
     }
 
+    public static OrderTable createUnOccupiedOrderTable(final String name, final int numberOfGuests) {
+        return createOrderTable(name, numberOfGuests, false);
+    }
+
+    public static OrderTable createOccupiedTable() {
+        return createOrderTable("테이블1", 0, true);
+    }
+
+    public static OrderTable createOrderTable() {
+        return createOrderTable("테이블1", 0, false);
+    }
+
     public static OrderTable createOrderTableRequest(final String name, final int numberOfGuests, final boolean occupied) {
         final OrderTable orderTable = new OrderTable();
         orderTable.setName(name);

--- a/src/test/java/kitchenpos/fixture/ProductFixture.java
+++ b/src/test/java/kitchenpos/fixture/ProductFixture.java
@@ -1,0 +1,18 @@
+package kitchenpos.fixture;
+
+import kitchenpos.domain.Product;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public class ProductFixture {
+
+    public static Product createProduct(final String name, final BigDecimal price) {
+        final Product product = new Product();
+        product.setId(UUID.randomUUID());
+        product.setName(name);
+        product.setPrice(price);
+        return product;
+    }
+
+}

--- a/src/test/java/kitchenpos/fixture/ProductFixture.java
+++ b/src/test/java/kitchenpos/fixture/ProductFixture.java
@@ -15,4 +15,11 @@ public class ProductFixture {
         return product;
     }
 
+    public static Product createProductRequest(final String name, final BigDecimal price) {
+        final Product product = new Product();
+        product.setName(name);
+        product.setPrice(price);
+        return product;
+    }
+
 }

--- a/src/test/java/kitchenpos/repository/InMemoryMenuGroupRepository.java
+++ b/src/test/java/kitchenpos/repository/InMemoryMenuGroupRepository.java
@@ -1,0 +1,28 @@
+package kitchenpos.repository;
+
+import kitchenpos.domain.MenuGroup;
+import kitchenpos.domain.MenuGroupRepository;
+
+import java.util.*;
+
+public class InMemoryMenuGroupRepository implements MenuGroupRepository {
+
+    private final Map<UUID, MenuGroup> menuGroups = new HashMap<>();
+
+    @Override
+    public MenuGroup save(final MenuGroup menuGroup) {
+        menuGroups.put(menuGroup.getId(), menuGroup);
+        return menuGroup;
+    }
+
+    @Override
+    public Optional<MenuGroup> findById(final UUID id) {
+        return Optional.ofNullable(menuGroups.get(id));
+    }
+
+    @Override
+    public List<MenuGroup> findAll() {
+        return new ArrayList<>(menuGroups.values());
+    }
+
+}

--- a/src/test/java/kitchenpos/repository/InMemoryMenuRepository.java
+++ b/src/test/java/kitchenpos/repository/InMemoryMenuRepository.java
@@ -1,0 +1,47 @@
+package kitchenpos.repository;
+
+import kitchenpos.domain.Menu;
+import kitchenpos.domain.MenuRepository;
+
+import java.util.*;
+
+public class InMemoryMenuRepository implements MenuRepository {
+
+    private final Map<UUID, Menu> menus = new HashMap<>();
+
+    @Override
+    public Menu save(Menu menu) {
+        menu.setId(UUID.randomUUID());
+        menus.put(menu.getId(), menu);
+        return menu;
+    }
+
+    @Override
+    public Optional<Menu> findById(UUID id) {
+        return Optional.ofNullable(menus.get(id));
+    }
+
+    @Override
+    public List<Menu> findAllByIdIn(List<UUID> ids) {
+        return menus.values()
+                .stream()
+                .filter(menu -> ids.contains(menu.getId()))
+                .toList();
+    }
+
+    @Override
+    public List<Menu> findAllByProductId(UUID productId) {
+        return menus.values()
+                .stream()
+                .filter(menu -> menu.getMenuProducts()
+                        .stream()
+                        .anyMatch(menuProduct -> menuProduct.getProductId().equals(productId)))
+                .toList();
+    }
+
+    @Override
+    public List<Menu> findAll() {
+        return new ArrayList<>(menus.values());
+    }
+
+}

--- a/src/test/java/kitchenpos/repository/InMemoryOrderRepository.java
+++ b/src/test/java/kitchenpos/repository/InMemoryOrderRepository.java
@@ -1,0 +1,38 @@
+package kitchenpos.repository;
+
+import kitchenpos.domain.Order;
+import kitchenpos.domain.OrderRepository;
+import kitchenpos.domain.OrderStatus;
+import kitchenpos.domain.OrderTable;
+
+import java.util.*;
+
+public class InMemoryOrderRepository implements OrderRepository {
+
+    private final Map<UUID, Order> orders = new HashMap<>();
+
+    @Override
+    public Order save(Order order) {
+        order.setId(UUID.randomUUID());
+        orders.put(order.getId(), order);
+        return order;
+    }
+
+    @Override
+    public Optional<Order> findById(UUID id) {
+        return Optional.ofNullable(orders.get(id));
+    }
+
+    @Override
+    public List<Order> findAll() {
+        return new ArrayList<>(orders.values());
+    }
+
+    @Override
+    public boolean existsByOrderTableAndStatusNot(OrderTable orderTable, OrderStatus status) {
+        return orders.values()
+                .stream()
+                .anyMatch(order -> order.getOrderTable().equals(orderTable) && !order.getStatus().equals(status));
+    }
+
+}

--- a/src/test/java/kitchenpos/repository/InMemoryOrderTableRepository.java
+++ b/src/test/java/kitchenpos/repository/InMemoryOrderTableRepository.java
@@ -1,0 +1,29 @@
+package kitchenpos.repository;
+
+import kitchenpos.domain.OrderTable;
+import kitchenpos.domain.OrderTableRepository;
+
+import java.util.*;
+
+public class InMemoryOrderTableRepository implements OrderTableRepository {
+
+    private final Map<UUID, OrderTable> orderTables = new HashMap<>();
+
+    @Override
+    public OrderTable save(OrderTable orderTable) {
+        orderTable.setId(UUID.randomUUID());
+        orderTables.put(orderTable.getId(), orderTable);
+        return orderTable;
+    }
+
+    @Override
+    public Optional<OrderTable> findById(UUID id) {
+        return Optional.ofNullable(orderTables.get(id));
+    }
+
+    @Override
+    public List<OrderTable> findAll() {
+        return new ArrayList<>(orderTables.values());
+    }
+
+}

--- a/src/test/java/kitchenpos/repository/InMemoryProductRepository.java
+++ b/src/test/java/kitchenpos/repository/InMemoryProductRepository.java
@@ -1,0 +1,36 @@
+package kitchenpos.repository;
+
+import kitchenpos.domain.Product;
+import kitchenpos.domain.ProductRepository;
+
+import java.util.*;
+
+public class InMemoryProductRepository implements ProductRepository {
+
+    private final Map<UUID, Product> products = new HashMap<>();
+
+    @Override
+    public Product save(Product product) {
+        product.setId(UUID.randomUUID());
+        products.put(product.getId(), product);
+        return product;
+    }
+
+    @Override
+    public Optional<Product> findById(UUID id) {
+        return Optional.ofNullable(products.get(id));
+    }
+
+    @Override
+    public List<Product> findAll() {
+        return new ArrayList<>(products.values());
+    }
+
+    @Override
+    public List<Product> findAllByIdIn(List<UUID> ids) {
+        return products.values()
+                .stream()
+                .filter(product -> ids.contains(product.getId()))
+                .toList();
+    }
+}


### PR DESCRIPTION
안녕하세요! 늦었지만 PR 드립니다.
서비스 클래스에 대한 단위테스트를 작성할까 고민하다가 통합테스트를 작성했습니다. 나중에 리팩토링을 진행하면 서비스 코드가 많이 변경될텐데 통합테스트로 구현하면 테스트 코드 수정이 비교적 적지 않을까 생각했습니다. Order 관련 테스트 코드는 분량이 많아 작업중입니다.
이번 과제 수행중 궁금한 내용은 테스트 데이터 초기화입니다. 테스트 메서드 시작전에 repository를 사용해 DB에 데이터를 추가했는데, 테스트 종료 후 `menuRepository.deleteAll()`을 호출하면 MenuProduct와 외래키 제약때문에 오류가 발생했습니다. repository로 delete를 호출하지 않는 방식을 생각해봤습니다.
- `@Transactional`을 붙이면 메서드 종료 후 롤백을 수행하지만, 트랜잭션 범위를 테스트 메서드까지 확장하는건 적절하지 않은 방식 같습니다.
- sql을 작성해서 테스트 전후에 삽입, 삭제 쿼리를 실행하면 테스트 데이터 관리가 명확해지지만 SQL까지 관리해야하는 점이 번거로울 것 같습니다.
지금은 관리해야할 내용이 추가되더라도 테스트용 SQL 파일을 추가하는게 맞지 않을까 생각중입니다. 연관관계가 복잡한 테스트 데이터가 필요할 때 어떻게 관리할 수 있을지 질문드립니다.
감사합니다!
